### PR TITLE
Fix external ERC links

### DIFF
--- a/ERCS/erc-6900.md
+++ b/ERCS/erc-6900.md
@@ -13,7 +13,7 @@ requires: 165, 4337
 
 ## Abstract
 
-This proposal standardizes smart contract accounts and account plugins, which are smart contract interfaces that allow for composable logic within smart contract accounts. This proposal is compliant with [ERC-4337](./eip-4337.md), and takes inspiration from [ERC-2535](./eip-2535.md) when defining interfaces for updating and querying modular function implementations.
+This proposal standardizes smart contract accounts and account plugins, which are smart contract interfaces that allow for composable logic within smart contract accounts. This proposal is compliant with [ERC-4337](./erc-4337.md), and takes inspiration from [ERC-2535](./erc-2535.md) when defining interfaces for updating and querying modular function implementations.
 
 This modular approach splits account functionality into three categories, implements them in external contracts, and defines an expected execution flow from accounts.
 


### PR DESCRIPTION
Previously, the links to ERC-4337 and ERC-2535 incorrectly used "eip" in the file name of the link.